### PR TITLE
chore: refactor the racket logic to a class

### DIFF
--- a/src/crystal_pong.cr
+++ b/src/crystal_pong.cr
@@ -37,6 +37,24 @@ module CrystalPong
       @shape = SF::RectangleShape.new(SF.vector2(RACKET_WIDTH, RACKET_HEIGHT))
     end
 
+    def move(x, y)
+      super(x, y)
+
+      limit_movement()
+    end
+
+    # Limits the racket to pass the window boundaries (up and down).
+    private def limit_movement
+      low = 0.0
+      high = (WINDOW_HEIGHT - RACKET_HEIGHT).to_f
+
+      if self.position.y < low
+        self.position = {self.position.x, low}
+      elsif self.position.y > high
+        self.position = {self.position.x, high}
+      end
+    end
+
     def draw(target, states)
       states.transform *= self.transform
 
@@ -114,9 +132,6 @@ module CrystalPong
 
     window.clear
 
-    clamp(racket_1, 0.0, (WINDOW_HEIGHT - RACKET_HEIGHT).to_f)
-    clamp(racket_2, 0.0, (WINDOW_HEIGHT - RACKET_HEIGHT).to_f)
-
     left_racket.move(0.0, -PLAYER_SPEED * dt) if SF::Keyboard.key_pressed?(SF::Keyboard::W)
     left_racket.move(0.0, PLAYER_SPEED * dt) if SF::Keyboard.key_pressed?(SF::Keyboard::S)
     right_racket.move(0.0, -PLAYER_SPEED * dt) if SF::Keyboard.key_pressed?(SF::Keyboard::Up)
@@ -155,13 +170,5 @@ module CrystalPong
     window.draw(center_line)
 
     window.display
-  end
-
-  def self.clamp(racket, low : Float64, high : Float64)
-    if racket.position[1] < low
-      racket.position = {racket.position[0], low}
-    elsif racket.position[1] > high
-      racket.position = {racket.position[0], high}
-    end
   end
 end

--- a/src/crystal_pong.cr
+++ b/src/crystal_pong.cr
@@ -81,9 +81,6 @@ module CrystalPong
   right_racket.position = SF.vector2(WINDOW_WIDTH - RACKET_WIDTH - RACKET_PADDING, WINDOW_HEIGHT_HALF - RACKET_HEIGHT_HALF)
 
   struct MainState
-    getter player_1_pos : Tuple(Int32, Int32)
-    getter player_2_pos : Tuple(Int32, Int32)
-
     getter ball_pos : Tuple(Int32, Int32)
     property ball_vel : SF::Vector2(Float64)
 
@@ -91,12 +88,6 @@ module CrystalPong
     property player_2_score : Int32
 
     def initialize
-      @player_1_pos = {RACKET_PADDING, (WINDOW_HEIGHT_HALF - RACKET_HEIGHT_HALF).to_i}
-      @player_2_pos = {
-        (WINDOW_WIDTH - RACKET_WIDTH - RACKET_PADDING).to_i,
-        (WINDOW_HEIGHT_HALF - RACKET_HEIGHT_HALF).to_i,
-      }
-
       @ball_pos = {WINDOW_WIDTH_HALF.to_i, (WINDOW_HEIGHT_HALF - BALL_RADIUS).to_i}
       @ball_vel = randomize_vec(SF::Vector2.new(0.0, 0.0), BALL_SPEED, BALL_SPEED)
 

--- a/src/crystal_pong.cr
+++ b/src/crystal_pong.cr
@@ -12,8 +12,8 @@ module CrystalPong
   WINDOW_HEIGHT_HALF = WINDOW_HEIGHT * 0.5
   WINDOW_WIDTH_HALF  = WINDOW_WIDTH * 0.5
 
-  RACKET_WIDTH       =  20
-  RACKET_HEIGHT      = 125
+  RACKET_WIDTH       =  20.0
+  RACKET_HEIGHT      = 125.0
   RACKET_WIDTH_HALF  = RACKET_WIDTH * 0.5
   RACKET_HEIGHT_HALF = RACKET_HEIGHT * 0.5
   RACKET_PADDING     = 50
@@ -27,6 +27,28 @@ module CrystalPong
   CENTER_LINE_THICKNESS = 3
 
   window = SF::RenderWindow.new(SF::VideoMode.new(WINDOW_WIDTH, WINDOW_HEIGHT), "Crystal Pong")
+
+  class Racket < SF::Transformable
+    include SF::Drawable
+
+    def initialize
+      super()
+
+      @shape = SF::RectangleShape.new(SF.vector2(RACKET_WIDTH, RACKET_HEIGHT))
+    end
+
+    def draw(target, states)
+      states.transform *= self.transform
+
+      target.draw(@shape, states)
+    end
+  end
+
+  left_racket = Racket.new
+  right_racket = Racket.new
+
+  left_racket.position = SF.vector2(RACKET_PADDING, WINDOW_HEIGHT_HALF - RACKET_HEIGHT_HALF)
+  right_racket.position = SF.vector2(WINDOW_WIDTH - RACKET_WIDTH - RACKET_PADDING, WINDOW_HEIGHT_HALF - RACKET_HEIGHT_HALF)
 
   struct MainState
     getter player_1_pos : Tuple(Int32, Int32)
@@ -66,9 +88,6 @@ module CrystalPong
 
   clock = SF::Clock.new
 
-  racket_1 = SF::RectangleShape.new(SF.vector2(RACKET_WIDTH, RACKET_HEIGHT))
-  racket_2 = SF::RectangleShape.new(SF.vector2(RACKET_WIDTH, RACKET_HEIGHT))
-
   ball = SF::RectangleShape.new(SF.vector2(BALL_SIZE, BALL_SIZE))
 
   file_path = Path["assets/alterebro-pixel-font.ttf"].expand(home: true).to_s
@@ -77,9 +96,6 @@ module CrystalPong
   scoreboard.color = SF::Color::White
   scoreboard_width_half = scoreboard.local_bounds.width * 0.5
   scoreboard.position = SF.vector2(WINDOW_WIDTH_HALF - scoreboard_width_half, 0.0)
-
-  racket_1.position = main_state.player_1_pos
-  racket_2.position = main_state.player_2_pos
 
   ball.position = main_state.ball_pos
 
@@ -101,10 +117,10 @@ module CrystalPong
     clamp(racket_1, 0.0, (WINDOW_HEIGHT - RACKET_HEIGHT).to_f)
     clamp(racket_2, 0.0, (WINDOW_HEIGHT - RACKET_HEIGHT).to_f)
 
-    racket_1.move(0, -PLAYER_SPEED * dt) if SF::Keyboard.key_pressed?(SF::Keyboard::W)
-    racket_1.move(0, PLAYER_SPEED * dt) if SF::Keyboard.key_pressed?(SF::Keyboard::S)
-    racket_2.move(0, -PLAYER_SPEED * dt) if SF::Keyboard.key_pressed?(SF::Keyboard::Up)
-    racket_2.move(0, PLAYER_SPEED * dt) if SF::Keyboard.key_pressed?(SF::Keyboard::Down)
+    left_racket.move(0.0, -PLAYER_SPEED * dt) if SF::Keyboard.key_pressed?(SF::Keyboard::W)
+    left_racket.move(0.0, PLAYER_SPEED * dt) if SF::Keyboard.key_pressed?(SF::Keyboard::S)
+    right_racket.move(0.0, -PLAYER_SPEED * dt) if SF::Keyboard.key_pressed?(SF::Keyboard::Up)
+    right_racket.move(0.0, PLAYER_SPEED * dt) if SF::Keyboard.key_pressed?(SF::Keyboard::Down)
 
     ball.position += main_state.ball_vel * dt
 
@@ -132,8 +148,8 @@ module CrystalPong
 
     scoreboard.string = "#{main_state.player_1_score}      #{main_state.player_2_score}"
 
-    window.draw(racket_1)
-    window.draw(racket_2)
+    window.draw(left_racket)
+    window.draw(right_racket)
     window.draw(ball)
     window.draw(scoreboard)
     window.draw(center_line)

--- a/src/crystal_pong.cr
+++ b/src/crystal_pong.cr
@@ -19,7 +19,7 @@ module CrystalPong
   RACKET_PADDING     = 50
 
   BALL_SIZE   =    20
-  BALL_SPEED  = 180.0
+  BALL_SPEED  = 240.0
   BALL_RADIUS = BALL_SIZE * 0.5
 
   PLAYER_SPEED = 400
@@ -111,8 +111,7 @@ module CrystalPong
 
   ball = SF::RectangleShape.new(SF.vector2(BALL_SIZE, BALL_SIZE))
 
-  file_path = Path["assets/alterebro-pixel-font.ttf"].expand(home: true).to_s
-  font = SF::Font.from_file(file_path)
+  font = SF::Font.from_file("assets/alterebro-pixel-font.ttf")
   scoreboard = SF::Text.new("#{main_state.player_1_score}      #{main_state.player_2_score}", font, 60)
   scoreboard.color = SF::Color::White
   scoreboard_width_half = scoreboard.local_bounds.width * 0.5
@@ -142,6 +141,7 @@ module CrystalPong
 
     ball.position += main_state.ball_vel * dt
 
+    # score count
     if ball.position.x < 0.0
       main_state.reset_ball(ball)
       main_state.player_2_score += 1

--- a/src/crystal_pong.cr
+++ b/src/crystal_pong.cr
@@ -37,6 +37,18 @@ module CrystalPong
       @shape = SF::RectangleShape.new(SF.vector2(RACKET_WIDTH, RACKET_HEIGHT))
     end
 
+    def collides?(entity : SF::Shape)
+      global_bounds.intersects?(entity.global_bounds)
+    end
+
+    private def local_bounds
+      @shape.local_bounds
+    end
+
+    private def global_bounds
+      self.transform.transform_rect(local_bounds())
+    end
+
     def move(x, y)
       super(x, y)
 
@@ -155,9 +167,9 @@ module CrystalPong
       main_state.ball_vel.y = -main_state.ball_vel.y.abs
     end
 
-    if racket_1.global_bounds.intersects?(ball.global_bounds)
+    if left_racket.collides?(ball)
       main_state.ball_vel.x = main_state.ball_vel.y.abs
-    elsif racket_2.global_bounds.intersects?(ball.global_bounds)
+    elsif right_racket.collides?(ball)
       main_state.ball_vel.x = -main_state.ball_vel.y.abs
     end
 

--- a/src/crystal_pong.cr
+++ b/src/crystal_pong.cr
@@ -1,5 +1,7 @@
 require "crsfml"
 
+require "./entities/racket.cr"
+
 #################################
 # Pong game built with Crystal. #
 #################################
@@ -28,54 +30,8 @@ module CrystalPong
 
   window = SF::RenderWindow.new(SF::VideoMode.new(WINDOW_WIDTH, WINDOW_HEIGHT), "Crystal Pong")
 
-  class Racket < SF::Transformable
-    include SF::Drawable
-
-    def initialize
-      super()
-
-      @shape = SF::RectangleShape.new(SF.vector2(RACKET_WIDTH, RACKET_HEIGHT))
-    end
-
-    def collides?(entity : SF::Shape)
-      global_bounds.intersects?(entity.global_bounds)
-    end
-
-    private def local_bounds
-      @shape.local_bounds
-    end
-
-    private def global_bounds
-      self.transform.transform_rect(local_bounds())
-    end
-
-    def move(x, y)
-      super(x, y)
-
-      limit_movement()
-    end
-
-    # Limits the racket to pass the window boundaries (up and down).
-    private def limit_movement
-      low = 0.0
-      high = (WINDOW_HEIGHT - RACKET_HEIGHT).to_f
-
-      if self.position.y < low
-        self.position = {self.position.x, low}
-      elsif self.position.y > high
-        self.position = {self.position.x, high}
-      end
-    end
-
-    def draw(target, states)
-      states.transform *= self.transform
-
-      target.draw(@shape, states)
-    end
-  end
-
-  left_racket = Racket.new
-  right_racket = Racket.new
+  left_racket = Entities::Racket.new
+  right_racket = Entities::Racket.new
 
   left_racket.position = SF.vector2(RACKET_PADDING, WINDOW_HEIGHT_HALF - RACKET_HEIGHT_HALF)
   right_racket.position = SF.vector2(WINDOW_WIDTH - RACKET_WIDTH - RACKET_PADDING, WINDOW_HEIGHT_HALF - RACKET_HEIGHT_HALF)

--- a/src/entities/racket.cr
+++ b/src/entities/racket.cr
@@ -1,0 +1,45 @@
+class CrystalPong::Entities::Racket < SF::Transformable
+  include SF::Drawable
+
+  def initialize
+    super()
+
+    @shape = SF::RectangleShape.new(SF.vector2(RACKET_WIDTH, RACKET_HEIGHT))
+  end
+
+  def collides?(entity : SF::Shape)
+    global_bounds.intersects?(entity.global_bounds)
+  end
+
+  private def local_bounds
+    @shape.local_bounds
+  end
+
+  private def global_bounds
+    self.transform.transform_rect(local_bounds())
+  end
+
+  def move(x, y)
+    super(x, y)
+
+    limit_movement()
+  end
+
+  # Limits the racket to pass the window boundaries (up and down).
+  private def limit_movement
+    low = 0.0
+    high = (WINDOW_HEIGHT - RACKET_HEIGHT).to_f
+
+    if self.position.y < low
+      self.position = {self.position.x, low}
+    elsif self.position.y > high
+      self.position = {self.position.x, high}
+    end
+  end
+
+  def draw(target, states)
+    states.transform *= self.transform
+
+    target.draw(@shape, states)
+  end
+end


### PR DESCRIPTION
The purpose of this refactor is to improve code readability and start organizing the game objects.

In the `collision?` method of the Racket, its rect is transformed with the Shape's local bounds one since the shape is what is used to check intersections.

The local geometric of the entity is the rectangle shape, since it's what internally composes the Racket entity, so the Racket's local bounding rect is just the shape's local bounds [¹](https://en.sfml-dev.org/forums/index.php?topic=22309.msg157114#msg157114).